### PR TITLE
Fix OpenAPI export path handling

### DIFF
--- a/app/routes/user/router.py
+++ b/app/routes/user/router.py
@@ -3,6 +3,6 @@ from common.schema import APIResponse, response_maker
 from . import model, schema
 router = APIRouter(prefix="/user", tags=["user"])
 
-@router.get("/", response_model=schema.UserResponse, responses=response_maker[404])
+@router.get("/", response_model=schema.UserResponse, responses=response_maker([404]))
 async def get_users(request: Request):
-    return APIResponse
+    return APIResponse()

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -1,7 +1,16 @@
 import importlib
 import json
 import sys
+from pathlib import Path
 from fastapi import FastAPI
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+APP_DIR = ROOT_DIR / "app"
+if APP_DIR.is_dir() and str(APP_DIR) not in sys.path:
+    sys.path.insert(0, str(APP_DIR))
+
 
 def load_app(app_path: str) -> FastAPI:
     try:


### PR DESCRIPTION
## Summary
- ensure the OpenAPI export script adds the project and app directories to sys.path so FastAPI modules can be imported
- update the user router to call response_maker correctly and return a concrete APIResponse instance

## Testing
- python scripts/export_openapi.py app.main:app

------
https://chatgpt.com/codex/tasks/task_e_6909bc5c0624832fabeee0fa137316f6