### PR TITLE
Set suppress flag during workflow builds

### DIFF
--- a/.github/workflows/build-swagger-docs.yml
+++ b/.github/workflows/build-swagger-docs.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   APP_MODULE: app.main:app  # <- FastAPI 앱 모듈 경로에 맞게 수정
+  SUPPRESS_VARIABLE_NOT_ASSIGNED_ERROR: "true"
 
 jobs:
   build:

--- a/app/common/env_utils.py
+++ b/app/common/env_utils.py
@@ -1,0 +1,28 @@
+"""Utility functions for accessing environment variables with optional suppression of missing-variable errors."""
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+
+class VariableNotAssignedError(Exception):
+    """Raised when a required environment variable has not been assigned."""
+
+
+_SUPPRESS_FLAG_ENV_NAME = "SUPPRESS_VARIABLE_NOT_ASSIGNED_ERROR"
+_TRUE_VALUES = {"1", "true", "yes", "y", "on"}
+
+
+def _should_suppress_missing_variable() -> bool:
+    value = os.getenv(_SUPPRESS_FLAG_ENV_NAME, "false")
+    return str(value).strip().lower() in _TRUE_VALUES
+
+
+def getenvval(key: str, default_value: Optional[Any] = None) -> Optional[Any]:
+    """Retrieve an environment variable, optionally raising if it is missing."""
+    value = os.getenv(key)
+    if value is not None:
+        return value
+    if default_value is not None or _should_suppress_missing_variable():
+        return default_value
+    raise VariableNotAssignedError(f"{key} environment variable is not set")

--- a/app/common/jwt_utils.py
+++ b/app/common/jwt_utils.py
@@ -1,11 +1,10 @@
 import time
 import jwt
-import os
 
-secret = os.getenv("JWT_SECRET", None)
+from .env_utils import getenvval
+
 algorithm = "HS256"
-if not secret:
-    raise Exception("JWT_SECRET environment variable is not set")
+secret = getenvval("JWT_SECRET")
 
 def generate_jwt(payload: dict):
     """


### PR DESCRIPTION
## Summary
- ensure the Swagger docs workflow sets `SUPPRESS_VARIABLE_NOT_ASSIGNED_ERROR` so missing secrets are ignored during CI runs

## Testing
- python -m compileall app/common/env_utils.py app/common/jwt_utils.py

------
https://chatgpt.com/codex/tasks/task_e_690a2f6cecd8832fb7dce43c3b1cd4dd